### PR TITLE
Allow version of Ruby up to 3.1.20

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    persistent-cache (1.1.1)
+    persistent-cache (2.0.0)
       eh (~> 1.0)
       persistent-cache-storage-api (~> 0.1.4)
       persistent-cache-storage-directory (~> 0.1.2)
@@ -11,61 +11,63 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    byebug (9.0.6)
+    byebug (11.1.3)
     coveralls (0.8.23)
       json (>= 1.8, < 3)
       simplecov (~> 0.16.1)
       term-ansicolor (~> 1.3)
       thor (>= 0.19.4, < 2.0)
       tins (~> 1.6)
-    diff-lcs (1.3)
-    docile (1.3.2)
+    diff-lcs (1.5.0)
+    docile (1.4.0)
     eh (1.0.0)
-    json (2.2.0)
-    persistent-cache-storage-api (0.1.5)
+    json (2.6.2)
+    persistent-cache-storage-api (0.1.6)
     persistent-cache-storage-directory (0.1.2)
       persistent-cache-storage-api
-    persistent-cache-storage-ram (0.1.2)
+    persistent-cache-storage-ram (0.1.3)
       eh
       persistent-cache-storage-api
-    persistent-cache-storage-sqlite (0.1.3)
+    persistent-cache-storage-sqlite (0.1.4)
       eh (~> 1.0.0)
       persistent-cache-storage-api (~> 0.1)
       sqlite3 (~> 1.4)
-    rake (12.3.2)
-    rspec (3.8.0)
-      rspec-core (~> 3.8.0)
-      rspec-expectations (~> 3.8.0)
-      rspec-mocks (~> 3.8.0)
-    rspec-core (3.8.2)
-      rspec-support (~> 3.8.0)
-    rspec-expectations (3.8.4)
+    rake (13.0.6)
+    rspec (3.11.0)
+      rspec-core (~> 3.11.0)
+      rspec-expectations (~> 3.11.0)
+      rspec-mocks (~> 3.11.0)
+    rspec-core (3.11.0)
+      rspec-support (~> 3.11.0)
+    rspec-expectations (3.11.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.8.0)
-    rspec-mocks (3.8.1)
+      rspec-support (~> 3.11.0)
+    rspec-mocks (3.11.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.8.0)
-    rspec-support (3.8.2)
+      rspec-support (~> 3.11.0)
+    rspec-support (3.11.0)
     simplecov (0.16.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
-    sqlite3 (1.4.1)
+    sqlite3 (1.4.4)
+    sync (0.5.0)
     term-ansicolor (1.7.1)
       tins (~> 1.0)
-    thor (0.20.3)
-    tins (1.20.3)
+    thor (1.2.1)
+    tins (1.31.1)
+      sync
 
 PLATFORMS
-  ruby
+  x86_64-darwin-21
 
 DEPENDENCIES
-  byebug (~> 9.0)
+  byebug (~> 11.1)
   coveralls (~> 0.8)
   persistent-cache!
-  rake (~> 12.3)
+  rake (= 13.0.6)
   rspec
 
 BUNDLED WITH
-   1.16.6
+   2.3.7

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Values in the cache have a default freshness period of 15465600 ms. This can be 
 
 Note that when using a back-end that requires marshalling (e.g. sqlite) the string encoding for []= and [] needs to be the same (e.g. UTF-8, US-ASCII, etc.) If the coding does not match, [] will not be able to find the entry during lookup and will return nil. See the section on 'Encoding' below for more detail.
 
-This gem was sponsored by Hetzner (Pty) Ltd - http://hetzner.co.za
+This gem was sponsored by xneelo (Pty) Ltd - https://xneelo.co.za
 
 ## StorageSQLite
 

--- a/lib/persistent-cache/version.rb
+++ b/lib/persistent-cache/version.rb
@@ -1,3 +1,3 @@
 module Persistent
-  VERSION = "1.1.1"
+  VERSION = "2.0.0"
 end

--- a/persistent-cache.gemspec
+++ b/persistent-cache.gemspec
@@ -16,12 +16,12 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.name          = 'persistent-cache'
   gem.require_paths = ['lib']
-  gem.required_ruby_version = '~> 2.0'
+  gem.required_ruby_version = ['>= 2.0', '< 3.1.20']
   gem.version       = Persistent::VERSION
-  gem.add_development_dependency 'rspec', '2.12.0'
+  gem.add_development_dependency 'rspec', '3.11.0'
   gem.add_development_dependency 'coveralls', '~> 0.8'
-  gem.add_development_dependency 'rake', '~> 12.3'
-  gem.add_development_dependency 'byebug', '~> 9.0'
+  gem.add_development_dependency 'rake', '13.0.6'
+  gem.add_development_dependency 'byebug', '~> 11.1'
   gem.add_dependency 'eh', '~> 1.0'
   gem.add_dependency 'persistent-cache-storage-api', '~> 0.1.4'
   gem.add_dependency 'persistent-cache-storage-sqlite', '~> 0.1.3'


### PR DESCRIPTION
Tested, with:
- ruby 3.1.2p20
- ruby 2.6.10p210

Tests passed successfully:
```
Finished in 4.37 seconds (files took 0.20376 seconds to load)
95 examples, 0 failures

Randomized with seed 5330
```

Addresses #7